### PR TITLE
Shared cluster sa

### DIFF
--- a/automation/roles/admin_config_shared_cluster_sa/tasks/main.yaml
+++ b/automation/roles/admin_config_shared_cluster_sa/tasks/main.yaml
@@ -1,0 +1,44 @@
+---
+- name: create service account
+  k8s:
+    host: "https://api.{{ cluster_address }}:443"
+    api_key: "{{ sa_token }}"
+    state: "{{ state }}"
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: externalsecret-operator-config-external-secrets
+        namespace: trident ##Openshift namespace where the secret going to be created in
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::{{ aws_account_id }}:role/{{ aws_iam_role_name }}  ##AWS ESO_ROLE_ARN
+
+- name: create service account
+  k8s:
+    host: "https://api.{{ cluster_address }}:443"
+    api_key: "{{ sa_token }}"
+    state: "{{ state }}"
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: externalsecret-operator-config-external-secrets ##Service account name that is listed in IAM Role
+        namespace: group-sync-operator ##Openshift namespace where the secret going to be created in
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::{{ aws_account_id }}:role/{{ aws_iam_role_name }}  ##AWS ESO_ROLE_ARN
+
+- name: create service account
+  k8s:
+    host: "https://api.{{ cluster_address }}:443"
+    api_key: "{{ sa_token }}"
+    state: "{{ state }}"
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: externalsecret-operator-config-external-secrets
+        namespace: openshift-logging ##Openshift namespace where the secret going to be created in
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::{{ aws_account_id }}:role/{{ aws_iam_role_name }}  ##AWS ESO_ROLE_ARN
+
+

--- a/automation/roles/admin_config_shared_cluster_sa/tasks/main.yaml
+++ b/automation/roles/admin_config_shared_cluster_sa/tasks/main.yaml
@@ -1,4 +1,10 @@
 ---
+- include_role:
+    name: admin_get_service_account_token
+  vars:
+    service_account_name: "{{ cluster_admin_service_account_name }}"
+    service_account_namespace: "{{ cluster_admin_service_account_namespace }}"
+    
 - name: create service account
   k8s:
     host: "https://api.{{ cluster_address }}:443"

--- a/automation/shared-cluster-day2.yaml
+++ b/automation/shared-cluster-day2.yaml
@@ -75,6 +75,8 @@
         name: admin_config_shared_cluster_sa
       vars:
         cluster_address: "{{ ocp_cluster_address }}"
+        admin_user: "{{ cluster_admin_user }}"
+        admin_password: "{{ cluster_admin_password }}"
              
 
     - include_role:

--- a/automation/shared-cluster-day2.yaml
+++ b/automation/shared-cluster-day2.yaml
@@ -72,6 +72,12 @@
         instance_type: r5a.xlarge
 
     - include_role:
+        name: admin_config_shared_cluster_sa
+      vars:
+        cluster_address: "{{ ocp_cluster_address }}"
+             
+
+    - include_role:
         name: admin_config_machine_pool
       vars:
         subnet: "{{ subnet_id3 }}"


### PR DESCRIPTION
This role was tested earlier today on 3M repo to created service account in the following namespaces: trident, group-sync-operator, openshift-logging along with including the annotation for aws role arn to pull secrets from AWS secret manager.