### PR TITLE
removed type: generic to prevent conflict

### DIFF
--- a/acm-policies/install-mco/config/policy-thanos-externalsecret.yaml
+++ b/acm-policies/install-mco/config/policy-thanos-externalsecret.yaml
@@ -17,7 +17,6 @@ spec:
     name: thanos-secret-store
   target:
     template:
-      type: generic
       data:
         thanos.yaml: "{{ `{{ .thanos_yaml }}` }}"
     creationPolicy: Owner


### PR DESCRIPTION
Removed type: generic to prevent conflict when the secret is being recreated with type: opaque